### PR TITLE
license using env var

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,6 +37,6 @@ jobs:
           ${{ runner.os }}-gradle-cache-
     - name: Gradle check
       env:
-        ORG_GRADLE_PROJECT_interlokLicense: ${{ secrets.INTERLOK_LICENSE_KEY }}
+        INTERLOK_LICENSE_KEY: ${{ secrets.INTERLOK_LICENSE_KEY }}
       run: |
         ./gradlew -Dorg.gradle.console=plain --no-daemon clean check

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,6 @@ ext {
     SOLACE_USER: "admin",
     SOLACE_PASSWORD: "admin"
   ]
-  // If running in a CI pipeline, then interlokLicense might be a secret so
-  // we cater for that to 'check' work, w/o a license-docker.properties or similar.
-  interlokLicense= project.findProperty('interlokLicense') ?: "false"
-  interlokVerifySystemProperties = interlokLicense != "false" ? [ "interlok.license.key" : interlokLicense ] : [:]
 }
 
 allprojects {


### PR DESCRIPTION
## Motivation

Switching to setting license as env var

## Modification

Removed gradle workaround and updated env var setting in pipeline

## Result

Aligning with parents expected way to set license

## Testing

```shell
export INTERLOK_LICENSE_KEY=".."
./gradlew clean check
```
